### PR TITLE
feat(shoppingcart): enable cors

### DIFF
--- a/src/main/java/shoppingcart/Application.java
+++ b/src/main/java/shoppingcart/Application.java
@@ -2,10 +2,23 @@ package shoppingcart;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @SpringBootApplication
 public class Application {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    @Configuration
+    public class CorsConfiguration implements WebMvcConfigurer {
+        public static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
+
+        @Override
+        public void addCorsMappings(final CorsRegistry registry) {
+            registry.addMapping("/api/**").allowedMethods(ALLOWED_METHOD_NAMES.split(","));
+        }
     }
 }

--- a/src/test/java/shoppingcart/acceptance/AcceptanceTest.java
+++ b/src/test/java/shoppingcart/acceptance/AcceptanceTest.java
@@ -1,0 +1,35 @@
+package shoppingcart.acceptance;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static shoppingcart.Application.CorsConfiguration.ALLOWED_METHOD_NAMES;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AcceptanceTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void cors() throws Exception {
+        mockMvc.perform(
+                options("/api/products")
+                        .header(HttpHeaders.ORIGIN, "http://localhost:8080")
+                        .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET")
+        )
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*"))
+                .andExpect(header().stringValues(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, ALLOWED_METHOD_NAMES))
+                .andDo(print())
+        ;
+    }
+}

--- a/src/test/java/shoppingcart/acceptance/AcceptanceTest.java
+++ b/src/test/java/shoppingcart/acceptance/AcceptanceTest.java
@@ -28,7 +28,7 @@ public class AcceptanceTest {
         )
                 .andExpect(status().isOk())
                 .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*"))
-                .andExpect(header().stringValues(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, ALLOWED_METHOD_NAMES))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, ALLOWED_METHOD_NAMES))
                 .andDo(print())
         ;
     }


### PR DESCRIPTION
- 교차 출처 리소스 공유 (CORS): https://developer.mozilla.org/ko/docs/Web/HTTP/CORS
- CORS는 왜 이렇게 우리를 힘들게 하는걸까?: https://evan-moon.github.io/2020/05/21/about-cors

---

Spring의 기본값입니다. (`CorsConfiguration#applyPermitDefaultValues()`)

- Allow all origins.
- Allow "simple" methods `GET`, `HEAD` and `POST`.
- Allow all headers.
- Set max age to 1800 seconds (30 minutes).